### PR TITLE
fix: default country connection is local country

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 __pycache__
 logs
+*.iml

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ $ poetry run pothos
 ```
 
 ## Flags
-| Flag    | Title           | Description                                                                      |
-|---------|-----------------|----------------------------------------------------------------------------------|
-| -h      | help            | Show help menu                                                                   |
-| -v      | version         | Show `pothos` version                                                            |
-| -p      | persist         | By default Pothos clears the terminal on each status refresh. Set -p to disable. |
-| -l      | list            | Show list of countries you can connect to.                                       |
-| -c name | country name    | Set which country you want to connect to. Default: United_States                 |
-| -s time | status interval | Interval to check NordVPN status. Default: 5m                                    |
-| -r time | reconnect time  | Interval to reconnect to NordVPN. Default: 4h                                    |
+| Flag    | Title           | Description                                                                                             |
+|---------|-----------------|---------------------------------------------------------------------------------------------------------|
+| -h      | help            | Show help menu                                                                                          |
+| -v      | version         | Show `pothos` version                                                                                   |
+| -p      | persist         | By default Pothos clears the terminal on each status refresh. Set -p to disable.                        |
+| -l      | list            | Show list of countries you can connect to.                                                              |
+| -c name | country name    | Set which country you want to connect to. <br/>Default: Fastest connecting country as chosen by NordVPN |
+| -s time | status interval | Interval to check NordVPN status. Default: 5m                                                           |
+| -r time | reconnect time  | Interval to reconnect to NordVPN. Default: 4h                                                           |
 
 
 ## Examples
@@ -58,7 +58,7 @@ $ poetry run pothos
 $ pothos -c Canada -s 5s -r 3h
 ```
 
-> Connect to a NordVPN server in the United_States (default). Show a status update every 5 ninutes (default) and connect to a new server every 20 minutes. Persist is set, so the terminal will not clear on each status update.
+> Connect to a NordVPN server in a country that NordVPN chooses. Show a status update every 5 ninutes (default) and connect to a new server every 20 minutes. Persist is set, so the terminal will not clear on each status update.
 ```shell
 $ pothos -r 20m -p
 ```

--- a/pothos/main.py
+++ b/pothos/main.py
@@ -1,27 +1,37 @@
+import sys
+
 from termcolor import cprint
-from pothos.manager import Manager
+from pothos.nord_vpn_manager import NordVPNManager
 from pothos.logging import configure_logging
-from pothos.types import Unit, MenuArgs, Defaults
+from pothos.types import Unit, MenuArgs, BaseValues
 from pothos.parser import pothos_argument_parser
 
 
 def run_pothos():
     configure_logging()
-
-    defaults: Defaults = {
-        'country': 'United_States',
+    defaults: BaseValues = {
+        'country': None,
         'status': {'quantity': 5, 'unit': Unit.MINUTE},
         'reconnect': {'quantity': 4, 'unit': Unit.HOUR}
     }
-
-    menu_args: MenuArgs = pothos_argument_parser(defaults['country'], defaults['status'], defaults['reconnect'])
+    menu_args: MenuArgs = pothos_argument_parser(
+        defaults['country'],
+        defaults['status'],
+        defaults['reconnect']
+    )
 
     try:
-        pothos = Manager(
-            menu_args['persist'], menu_args['show_countries'], menu_args['country'],
-            menu_args['status'], menu_args['reconnect']
-        )
-        pothos.run()
+        if menu_args['show_countries']:
+            NordVPNManager.print_country_list()
+            sys.exit()
+        else:
+            pothos = NordVPNManager(
+                menu_args['persist'],
+                menu_args['country'],
+                menu_args['status'],
+                menu_args['reconnect']
+            )
+            pothos.run()
     except Exception as e:
         cprint(f'{e}', 'red', attrs=['bold'])
         menu_args['help']()

--- a/pothos/nord_vpn.py
+++ b/pothos/nord_vpn.py
@@ -5,29 +5,27 @@ from pothos.types import NordVPNConnect
 
 
 class NordVPN:
-    def __init__(self):
-        self.version = self._get_version()
-        self.countries = self._get_countries()
-
     @staticmethod
-    def _get_version() -> str:
+    def get_version() -> str:
         version_raw: subprocess.CompletedProcess = subprocess.run(
             'nordvpn version', shell=True, text=True, capture_output=True
         )
 
         version: str = version_raw.stdout.strip() \
+            .replace('A new version of NordVPN is available! Please update the application.', '') \
             .replace('\n-', '').strip('-') \
             .replace('NordVPN Version', '').strip()
 
         return version
 
     @staticmethod
-    def _get_countries() -> list[str]:
+    def get_countries() -> list[str]:
         countries_raw: subprocess.CompletedProcess = subprocess.run(
             'nordvpn countries list', shell=True, text=True, capture_output=True
         )
 
         country_list: list[str] = countries_raw.stdout.strip() \
+            .replace('A new version of NordVPN is available! Please update the application.', '') \
             .replace('\n-', '').replace('\n', '\t') \
             .strip('-').strip() \
             .replace('\t\t', '\t').replace('\t\t', '\t') \
@@ -49,12 +47,15 @@ class NordVPN:
 
     @staticmethod
     def connect(country: str) -> NordVPNConnect:
+        selected_country: str = f' {country}' if country else ''
+        subprocess_connect_command: str = f'nordvpn c{selected_country}'
         spinner = Halo(text='Connecting...')
         is_connected: bool = False
         debug: list[str] = []
 
-        p: subprocess.Popen = subprocess.Popen(f'nordvpn c {country}', shell=True, stdout=subprocess.PIPE)
+        p: subprocess.Popen = subprocess.Popen(subprocess_connect_command, shell=True, stdout=subprocess.PIPE)
         spinner.start()
+
         while True:
             line_raw: str = p.stdout.readline().decode('utf-8').strip()
             line: str = line_raw.replace('-', '').replace('/', '').replace('\\', '').replace('|', '').strip()

--- a/pothos/nord_vpn.py
+++ b/pothos/nord_vpn.py
@@ -51,8 +51,8 @@ class NordVPN:
 
     @staticmethod
     def connect(country: str) -> NordVPNConnect:
-        selected_country: str = f' {country}' if country else ''
-        subprocess_connect_command: str = f'nordvpn c{selected_country}'
+        selected_country: str = country or ''
+        subprocess_connect_command: str = f'nordvpn c {selected_country}'.rstrip()
         spinner = Halo(text='Connecting...')
         is_connected: bool = False
         debug: list[str] = []

--- a/pothos/nord_vpn.py
+++ b/pothos/nord_vpn.py
@@ -6,13 +6,17 @@ from pothos.types import NordVPNConnect
 
 class NordVPN:
     @staticmethod
+    def _get_update_alert() -> str:
+        return 'A new version of NordVPN is available! Please update the application.'
+
+    @staticmethod
     def get_version() -> str:
         version_raw: subprocess.CompletedProcess = subprocess.run(
             'nordvpn version', shell=True, text=True, capture_output=True
         )
 
         version: str = version_raw.stdout.strip() \
-            .replace('A new version of NordVPN is available! Please update the application.', '') \
+            .replace(NordVPN._get_update_alert(), '') \
             .replace('\n-', '').strip('-') \
             .replace('NordVPN Version', '').strip()
 
@@ -25,7 +29,7 @@ class NordVPN:
         )
 
         country_list: list[str] = countries_raw.stdout.strip() \
-            .replace('A new version of NordVPN is available! Please update the application.', '') \
+            .replace(NordVPN._get_update_alert(), '') \
             .replace('\n-', '').replace('\n', '\t') \
             .strip('-').strip() \
             .replace('\t\t', '\t').replace('\t\t', '\t') \

--- a/pothos/nord_vpn_manager.py
+++ b/pothos/nord_vpn_manager.py
@@ -27,7 +27,7 @@ class NordVPNManager:
 
     @staticmethod
     def _is_valid_country(country: Country) -> bool:
-        if country not in NordVPN.get_countries() and country is not None:
+        if country and country not in NordVPN.get_countries():
             color_print(f'{country} is not a valid country.', 'red')
             NordVPNManager.print_country_list()
             sys.exit()
@@ -80,10 +80,12 @@ class NordVPNManager:
             ('Status Last Updated: ', datetime.now().strftime("%m/%d/%Y %H:%M:%S")),
             ('Previous External IP: ', to_color(self._prev_external_ip, 'yellow')),
             ('Current External IP: ', to_color(self._curr_external_ip, 'green')),
-            ('Country: ', to_color(self._country)),
             ('Status Interval: ', to_color(f'{self._status["quantity"]}{self._status["unit"].value}')),
             ('Reconnect Interval: ', to_color(f'{self._reconnect["quantity"]}{self._reconnect["unit"].value}'))
         ]
+
+        if self._country:
+            detail_list.append(('Country: ', to_color(self._country)))
 
         for item in detail_list:
             print(f'{item[0].ljust(40, "-")} {item[1]}')

--- a/pothos/parser.py
+++ b/pothos/parser.py
@@ -6,6 +6,7 @@ from pothos.utils import to_color
 
 def pothos_argument_parser(default_country: Country, default_status: Interval, default_reconnect: Interval) -> MenuArgs:
     pothos_version: str = version('pothos')
+    default_country_str: str = default_country or 'Fastest connecting country as chosen by NordVPN'
     default_status_str: str = f'{default_status["quantity"]}{default_status["unit"].value}'
     default_reconnect_str: str = f'{default_reconnect["quantity"]}{default_reconnect["unit"].value}'
     quantity_str: str = to_color('quantity', 'green')
@@ -29,7 +30,7 @@ def pothos_argument_parser(default_country: Country, default_status: Interval, d
 
     parser.add_argument('-c', '--country',
                         help='Set which country you want to connect to.\n'
-                             f'Default country: {to_color("Fastest connecting country as chosen by NordVPN")}\n ',
+                             f'Default country: {to_color(default_country_str)}\n ',
                         default=default_country,
                         metavar='name')
 

--- a/pothos/parser.py
+++ b/pothos/parser.py
@@ -29,7 +29,7 @@ def pothos_argument_parser(default_country: Country, default_status: Interval, d
 
     parser.add_argument('-c', '--country',
                         help='Set which country you want to connect to.\n'
-                             f'Default country: {to_color("Local Country as detected by NordVPN")}\n ',
+                             f'Default country: {to_color("Fastest connecting country as chosen by NordVPN")}\n ',
                         default=default_country,
                         metavar='name')
 

--- a/pothos/parser.py
+++ b/pothos/parser.py
@@ -17,6 +17,7 @@ def pothos_argument_parser(default_country: Country, default_status: Interval, d
     )
 
     parser.add_argument('-v', '--version', action='version', version=f'Pothos version {pothos_version}')
+
     parser.add_argument('-p', '--persist',
                         help='By default Pothos clears the terminal on each status refresh.\n'
                              'Set -p to disable this feature.\n ',
@@ -28,7 +29,7 @@ def pothos_argument_parser(default_country: Country, default_status: Interval, d
 
     parser.add_argument('-c', '--country',
                         help='Set which country you want to connect to.\n'
-                             f'Default country: {to_color(default_country)}\n ',
+                             f'Default country: {to_color("Local Country as detected by NordVPN")}\n ',
                         default=default_country,
                         metavar='name')
 

--- a/pothos/types.py
+++ b/pothos/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TypedDict, Callable
+from typing import TypedDict, Callable, Union
 
 
 Persist = bool
@@ -30,8 +30,8 @@ class MenuArgs(TypedDict):
     help: Callable
 
 
-class Defaults(TypedDict):
-    country: Country
+class BaseValues(TypedDict):
+    country: Union[Country | None]
     status: Interval
     reconnect: Interval
 


### PR DESCRIPTION
This change updates Pothos to use NordVPN's fastest connecting server as the default connection (i.e. when a specific country to connect to is not supplied). NordVPN's fastest connecting server is usually the local  country or nearest local country from which the connection is being attempted from.  This is done by basically making the default NordVPN command:

`nordvpn c`

... as oppose to ...

`nordvpn c {default_configured_country}`

This could be useful for users that do not want the default country to be the United States for whatever reason.

Other Changes:

- NordVPN class was updated to have only static methods.  This makes it so that we do not have to instantiate an instance of the NordVPN class, since it is mostly used as a utility class.  This could make it easier to use and less prone to side effects in the future as state is not saved.   
- Manager class was renamed to NordVPNManager as the Manager class is very specific to managing NordVPN.  This is done in an attempt to increase readability.
- An attempt was make to remove NordVPN's new version alert (_'A new version of NordVPN is available! Please update the application.'_) from the get_version() and get_countries() return strings, as is messed with formatting.  The alert is still visible in the general status section.