### PR TITLE
feat: add option to restart NordVPN daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,16 @@ $ poetry run pothos
 ```
 
 ## Flags
-| Flag    | Title           | Description                                                                                             |
-|---------|-----------------|---------------------------------------------------------------------------------------------------------|
-| -h      | help            | Show help menu                                                                                          |
-| -v      | version         | Show `pothos` version                                                                                   |
-| -p      | persist         | By default Pothos clears the terminal on each status refresh. Set -p to disable.                        |
-| -l      | list            | Show list of countries you can connect to.                                                              |
-| -c name | country name    | Set which country you want to connect to. <br/>Default: Fastest connecting country as chosen by NordVPN |
-| -s time | status interval | Interval to check NordVPN status. Default: 5m                                                           |
-| -r time | reconnect time  | Interval to reconnect to NordVPN. Default: 4h                                                           |
+| Flag    | Title                 | Description                                                                                             |
+|---------|-----------------------|---------------------------------------------------------------------------------------------------------|
+| -h      | help                  | Show help menu                                                                                          |
+| -v      | version               | Show `pothos` version                                                                                   |
+| -p      | persist               | By default Pothos clears the terminal on each status refresh. Set -p to disable.                        |
+| -l      | list                  | Show list of countries you can connect to.                                                              |
+| -f      | force service restart | Attempt to restart NordVPN daemon if NordVPN is not connected.                                          |
+| -c name | country name          | Set which country you want to connect to. <br/>Default: Fastest connecting country as chosen by NordVPN |
+| -s time | status interval       | Interval to check NordVPN status. Default: 5m                                                           |
+| -r time | reconnect time        | Interval to reconnect to NordVPN. Default: 4h<br/>                                                      |
 
 
 ## Examples

--- a/pothos/main.py
+++ b/pothos/main.py
@@ -1,6 +1,8 @@
 import sys
 
 from termcolor import cprint
+
+from pothos.nord_vpn import NordVPN
 from pothos.nord_vpn_manager import NordVPNManager
 from pothos.logging import configure_logging
 from pothos.types import Unit, MenuArgs, BaseValues
@@ -21,7 +23,10 @@ def run_pothos():
     )
 
     try:
-        if menu_args['show_countries']:
+        if menu_args['force_service_restart']:
+            NordVPNManager.force_service_restart()
+            sys.exit()
+        elif menu_args['show_countries']:
             NordVPNManager.print_country_list()
             sys.exit()
         else:

--- a/pothos/main.py
+++ b/pothos/main.py
@@ -1,8 +1,5 @@
 import sys
-
 from termcolor import cprint
-
-from pothos.nord_vpn import NordVPN
 from pothos.nord_vpn_manager import NordVPNManager
 from pothos.logging import configure_logging
 from pothos.types import Unit, MenuArgs, BaseValues

--- a/pothos/nord_vpn.py
+++ b/pothos/nord_vpn.py
@@ -80,3 +80,23 @@ class NordVPN:
             'connected': is_connected,
             'debug': debug
         }
+
+    @staticmethod
+    def is_connected() -> bool:
+        is_connected: bool = False
+        status_raw: subprocess.CompletedProcess = subprocess.run(
+            'nordvpn status', shell=True, text=True, capture_output=True
+        )
+        command_output: str = status_raw.stdout.strip()
+
+        if re.search('Status: Connected', command_output):
+            is_connected = True
+        return is_connected
+
+    @staticmethod
+    def is_daemon_enabled() -> bool:
+        status_raw = subprocess.run(
+            'systemctl is-enabled nordvpnd.service', shell=True, text=True, capture_output=True
+        )
+        command_output: str = status_raw.stdout.strip()
+        return command_output == 'enabled'

--- a/pothos/nord_vpn_manager.py
+++ b/pothos/nord_vpn_manager.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 
 import schedule
@@ -64,6 +65,20 @@ class NordVPNManager:
             print(country.ljust(25), end='')
             if count % 5 == 0:
                 print()
+
+    @staticmethod
+    def force_service_restart() -> None:
+        print('Checking to see whether NordVPN is disconnected...')
+        if not NordVPN.is_connected():
+            print('Checking to see whether the NordVPN daemon is available and enabled...')
+            if NordVPN.is_daemon_enabled():
+                print('Looks like NordVPN is disconnected and NordVPN daemon is currently enabled. '
+                      '\nAttempting to restart it, this may take a while...')
+                subprocess.run('sudo systemctl restart nordvpnd.service', shell=True, text=True, capture_output=True)
+                print('Service restart done.')
+        else:
+            print('\nSeems NordVPN is still connected.  '
+                  '\nA service restart is unreliable while NordVPN is still in a connected status.')
 
     def _print_header(self) -> None:
         status_color: str = 'green' if self._tested_nordvpn_version == self._user_nordvpn_version else 'yellow'

--- a/pothos/parser.py
+++ b/pothos/parser.py
@@ -54,9 +54,16 @@ def pothos_argument_parser(default_country: Country, default_status: Interval, d
                         default=default_reconnect_str,
                         metavar='time')
 
+    parser.add_argument('-f', '--force',
+                        help='Sometimes NordVPN can\'t connect after an internet connection change.\n'
+                             'This attempts to rectify by restarting the NordVPN service.'
+                             '(linux only, requires sudo privileges).\n ',
+                        action='store_true')
+
     args: argparse.Namespace = parser.parse_args()
 
     return {
+        'force_service_restart': args.force,
         'persist': args.persist,
         'show_countries': args.list,
         'country': args.country,

--- a/pothos/types.py
+++ b/pothos/types.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import TypedDict, Callable, Union
 
-
+Force = bool
 Persist = bool
 ShowCountries = bool
 Country = str
@@ -22,6 +22,7 @@ class Interval(TypedDict):
 
 
 class MenuArgs(TypedDict):
+    force_service_restart: Force
     persist: Persist
     show_countries: ShowCountries
     country: Country


### PR DESCRIPTION
Added command line option `-f` or `--force` to attempt to restart the NordVPN daemon.  The readMe was also update with the option.